### PR TITLE
Allow customers to view show and access create method

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -1,6 +1,6 @@
 class CustomersController < ApplicationController
   before_action :set_customer, only: [:show, :edit, :update, :destroy]
-  before_action :authenticate_branch!, except: [:new]
+  before_action :authenticate_branch!, except: [:new, :show, :create]
 
   # GET /customers
   # GET /customers.json

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -1,6 +1,6 @@
 class CustomersController < ApplicationController
   before_action :set_customer, only: [:show, :edit, :update, :destroy]
-  before_action :authenticate_branch!, except: [:new, :show, :create]
+  before_action :authenticate_branch!, except: [:new, :create]
 
   # GET /customers
   # GET /customers.json

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -38,13 +38,17 @@ class CustomersController < ApplicationController
 
     respond_to do |format|
       if @customer.save
-        format.html { redirect_to @customer, notice: 'Your response has been recorded! Thank you for shopping with Tapir Grocer.' }
-        format.json { render :show, status: :created, location: @customer }
+        redirect_url = "/customers/summary?full_name=" + @customer.full_name + "&nric_num=" + @customer.nric_num + "&temperature=" + @customer.temperature.to_s + "&branch_id=" + @customer.branch_id.to_s
+        format.html { redirect_to redirect_url, notice: 'Your response has been recorded! Thank you for shopping with Tapir Grocer.' }
+        format.json { render :summary, status: :created, location: @customer }
       else
         format.html { render :new }
         format.json { render json: @customer.errors, status: :unprocessable_entity }
       end
     end
+  end
+
+  def summary
   end
 
   # PATCH/PUT /customers/1
@@ -74,7 +78,9 @@ class CustomersController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_customer
-      @customer = Customer.find(params[:id])
+      if request.env['PATH_INFO'] != "/customers/summary"
+        @customer = Customer.find(params[:id])
+      end
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/views/customers/summary.html.erb
+++ b/app/views/customers/summary.html.erb
@@ -1,0 +1,21 @@
+<h1>Summary</h1>
+
+<p>
+  <strong>Full name:</strong>
+  <%= params[:full_name] %>
+</p>
+
+<p>
+  <strong>NRIC number:</strong>
+  <%= params[:nric_num] %>
+</p>
+
+<p>
+  <strong>Temperature:</strong>
+  <%= params[:temperature] %>
+</p>
+
+<p>
+  <strong>Branch:</strong>
+  <%= params[:branch_id] %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,16 @@
 Rails.application.routes.draw do
   devise_for :branches
-  resources :customers
+  resources :customers do
+    collection do
+      get :summary
+    end
+  end
 
   root  'home#index'
-  match 'home', to: 'home#index', via: 'get'
-  
   get   'home/about'
+  get   'customers/summary'
 
   match 'branches', to: 'branches#index', via: 'get'
+  match 'home', to: 'home#index', via: 'get'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Fixes #27 but customers are able to view other people's entries by editing the URL. We can mitigate this by making a summary page that is shown to the user upon form submission, instead of recycling the show page.