### PR TITLE
Generate QR code for each branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'jbuilder', '~> 2.7'
 
 # Gems used in this project go here
 gem 'devise', '~> 4.7', '>= 4.7.3'
+gem 'rqrcode'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    chunky_png (1.3.14)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     devise (4.7.3)
@@ -151,6 +152,10 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rqrcode (1.1.2)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 0.1)
+    rqrcode_core (0.1.2)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -219,6 +224,7 @@ DEPENDENCIES
   listen (~> 3.2)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
+  rqrcode
   sass-rails (>= 6)
   selenium-webdriver
   spring

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -78,7 +78,7 @@ class CustomersController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_customer
-      if request.env['PATH_INFO'] != "/customers/summary"
+      if request.env['PATH_INFO'] != "/customers/summary" || request.env['PATH_INFO'] != "/customers/qrcode" 
         @customer = Customer.find(params[:id])
       end
     end

--- a/app/views/customers/index.html.erb
+++ b/app/views/customers/index.html.erb
@@ -31,5 +31,8 @@
 <br>
 
 <% @branches = Branch.all %>
-<% new_customer_with_location_link = "/customers/new?branch_id=" + @branches[current_branch.id].id.to_s + " - " + @branches[current_branch.id].branch_name %>
-<%= link_to 'New Customer', new_customer_with_location_link %>
+<%= link_to 'New Customer', new_customer_path + "?branch_id=" + @branches[current_branch.id].id.to_s + " - " + @branches[current_branch.id].branch_name %>
+
+<br/>
+
+<%= link_to 'Generate QR code for this branch location', customers_qrcode_path + "?branch_id=" + @branches[current_branch.id].branch_name%>

--- a/app/views/customers/qrcode.html.erb
+++ b/app/views/customers/qrcode.html.erb
@@ -6,3 +6,9 @@
 <% qrcode = RQRCode::QRCode.new(request.original_url + "?branch_id=" + params[:branch_id]) %>
 <% svg = qrcode.as_svg(offset: 0, color: '000', shape_rendering: 'crispEdges', module_size: 6, standalone: true) %>
 <%= svg.html_safe %>
+
+
+<br />
+<br />
+
+<%= link_to 'Print view' %>

--- a/app/views/customers/qrcode.html.erb
+++ b/app/views/customers/qrcode.html.erb
@@ -1,1 +1,8 @@
 <h1>QR Code for <%= params[:branch_id] %></h1>
+
+<br/>
+
+<% require 'rqrcode' %>
+<% qrcode = RQRCode::QRCode.new(request.original_url + "?branch_id=" + params[:branch_id]) %>
+<% svg = qrcode.as_svg(offset: 0, color: '000', shape_rendering: 'crispEdges', module_size: 6, standalone: true) %>
+<%= svg.html_safe %>

--- a/app/views/customers/qrcode.html.erb
+++ b/app/views/customers/qrcode.html.erb
@@ -1,0 +1,1 @@
+<h1>QR Code for <%= params[:branch_id] %></h1>

--- a/app/views/customers/qrcode.html.erb
+++ b/app/views/customers/qrcode.html.erb
@@ -1,14 +1,19 @@
-<h1>QR Code for <%= params[:branch_id] %></h1>
+<center>
+    <h1>Welcome to Tapir Grocer @ <%= params[:branch_id] %></h1>
 
-<br/>
+    <br/>
 
-<% require 'rqrcode' %>
-<% qrcode = RQRCode::QRCode.new(request.original_url + "?branch_id=" + params[:branch_id]) %>
-<% svg = qrcode.as_svg(offset: 0, color: '000', shape_rendering: 'crispEdges', module_size: 6, standalone: true) %>
-<%= svg.html_safe %>
+    <p>Due to the current COVID-19 outbreak, the Ministry of Health requires us to ensure that your visit is logged to ease contact tracing efforts.</p>
+    <p>It would be much to our delight if you could scan the following QR code and fill up the form that follows.</p>
+
+    <% require 'rqrcode' %>
+    <% qrcode = RQRCode::QRCode.new(request.original_url + "?branch_id=" + params[:branch_id]) %>
+    <% svg = qrcode.as_svg(offset: 0, color: '000', shape_rendering: 'crispEdges', module_size: 6, standalone: true) %>
+    <%= svg.html_safe %>
 
 
-<br />
-<br />
+    <br />
+    <br />
 
-<%= link_to 'Print view' %>
+    <strong>Thank you for visiting Tapir Grocer!</strong>
+</center>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
   </head>
 
   <body>
-    <%= render 'layouts/header' %>
+    <%= render 'layouts/header' unless request.env['PATH_INFO'] == '/customers/qrcode' %>
     <div class="container">
       <br/>
       <% if notice %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,14 @@ Rails.application.routes.draw do
   resources :customers do
     collection do
       get :summary
+      get :qrcode
     end
   end
 
   root  'home#index'
   get   'home/about'
   get   'customers/summary'
+  get   'customers/qrcode'
 
   match 'branches', to: 'branches#index', via: 'get'
   match 'home', to: 'home#index', via: 'get'


### PR DESCRIPTION
Closes #26. `/customers/qrcode` is stripped of its navbar to have a more print-friendly view so branch owners can print the page and put it up on their shop.